### PR TITLE
the Spotify token is now persistent on refresh

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,12 +9,20 @@ import NavBar from "./components/NavBar";
 import HomePage from "./pages/HomePage";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
+import Redirect from "./pages/Redirect";
+import { setSpotifyToken } from "./store/spotifyToken/actions";
 
 function App() {
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(getUserWithStoredToken());
+    const spotifyToken = localStorage.getItem("spotifyToken");
+    if (!spotifyToken) {
+      return null;
+    } else {
+      return dispatch(setSpotifyToken(spotifyToken));
+    }
   }, [dispatch]);
 
   return (
@@ -23,6 +31,7 @@ function App() {
       <Switch>
         <Route path="/signup" component={Signup} />
         <Route path="/login" component={Login} />
+        <Route path="/redirect" component={Redirect} />
         <Route path="/" component={HomePage} exact />
       </Switch>
     </div>

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,41 +1,21 @@
-import { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { useSelector } from "react-redux";
+import { Link, useHistory } from "react-router-dom";
 
 import { selectUserToken } from "../store/user/selectors";
-import { setSpotifyToken } from "../store/spotifyToken/actions";
+
 import { selectSPOTIFYToken } from "../store/spotifyToken/selectors";
 
 import SpotifyMusic from "../spotify/SpotifyMusic";
 import MyPlayLists from "../components/MyPlayLists";
 
 export default function HomePage() {
-  const dispatch = useDispatch();
   const spotifyToken = useSelector(selectSPOTIFYToken);
   const userToken = useSelector(selectUserToken);
+  const history = useHistory();
 
-  useEffect(() => {
-    if (!spotifyToken) {
-      const data = getToken(window.location.hash);
-      // console.log(data.access_token);
-      const spotifyToken = data.access_token;
-      // console.log("spotify token:", spotifyToken);
-      localStorage.setItem("spotifyToken", spotifyToken);
-      dispatch(setSpotifyToken(spotifyToken));
-    }
-  }, [dispatch, spotifyToken]);
-
-  const getToken = (hash) => {
-    const afterHashTag = hash.substring(1);
-    const paramsInUrl = afterHashTag.split("&");
-    const paramsSplit = paramsInUrl.reduce((accumulater, currentValue) => {
-      const [key, value] = currentValue.split("=");
-      accumulater[key] = value;
-      return accumulater;
-    }, {});
-
-    return paramsSplit;
-  };
+  if (!userToken) {
+    history.push("/login");
+  }
 
   return (
     <div>

--- a/src/pages/Redirect.js
+++ b/src/pages/Redirect.js
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+
+import { selectSPOTIFYToken } from "../store/spotifyToken/selectors";
+import { setSpotifyToken } from "../store/spotifyToken/actions";
+
+export default function Redirect() {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const spotifyToken = useSelector(selectSPOTIFYToken);
+
+  useEffect(() => {
+    if (!spotifyToken) {
+      const data = getToken(window.location.hash);
+      // console.log(data.access_token);
+      const spotifyToken = data.access_token;
+      // console.log("spotify token:", spotifyToken);
+      localStorage.setItem("spotifyToken", spotifyToken);
+      dispatch(setSpotifyToken(spotifyToken));
+    }
+  }, [dispatch, spotifyToken]);
+
+  const getToken = (hash) => {
+    const afterHashTag = hash.substring(1);
+    const paramsInUrl = afterHashTag.split("&");
+    const paramsSplit = paramsInUrl.reduce((accumulater, currentValue) => {
+      const [key, value] = currentValue.split("=");
+      accumulater[key] = value;
+      return accumulater;
+    }, {});
+
+    return paramsSplit;
+  };
+
+  if (spotifyToken) {
+    history.push("/");
+  }
+  return (
+    <div>
+      <h3>Connected to Spotify</h3>
+    </div>
+  );
+}

--- a/src/spotify/LoginButton.js
+++ b/src/spotify/LoginButton.js
@@ -12,7 +12,7 @@ export default function SpotifyLoginButton() {
 
   const CLIENT_ID = client_id;
   const SPOTIFY_AUTHORIZE_ENDPOINT = "https://accounts.spotify.com/authorize";
-  const REDIRECT_URL = "http://localhost:3000/";
+  const REDIRECT_URL = "http://localhost:3000/redirect";
   const SPACE_DELIMITER = "%20";
   const SCOPES = [
     "streaming",

--- a/src/spotify/SpotifyMusic.js
+++ b/src/spotify/SpotifyMusic.js
@@ -57,8 +57,7 @@ export default function SearchSpotifyMusic() {
     setOffset(offset - 50);
     fetchMoreSongs();
   };
-  const resetOffset = (event) => {
-    event.preventDefault();
+  const resetOffset = () => {
     setOffset(offset - offset);
     fetchMoreSongs();
   };


### PR DESCRIPTION
The Spotify token is now persistent on refresh.

Created a redirect page, to redirect the user to after they sign in to Spotify. This page gets the Spotify token, stores it in redux and local storage. When there is a Spotify token the page will push to the homepage. redirect page is a "middleman".

On app.js the spotifyToken is taken from local storage to see if it's there, if it is, the Spotify token will be set to redux store again. This way the spotifyToken is persistent when the page is refreshed.