### PR TITLE
Changed the New Releases to Daily Top 50

### DIFF
--- a/src/components/SearchMusic.js
+++ b/src/components/SearchMusic.js
@@ -5,7 +5,7 @@ import "./SearchMusic.css";
 
 import { setSearchInput } from "../store/searchInput/actions";
 import {
-  fetchNewReleasesSpotify,
+  fetchDailyTop50Spotify,
   fetchSpotifyMusic,
 } from "../store/spotifyMusic/actions";
 import { clearPlaylistByID } from "../store/PlaylistByID/actions";
@@ -31,11 +31,11 @@ export default function SearchMusic() {
     }
 
     dispatch(clearPlaylistByID());
-    dispatch(fetchNewReleasesSpotify());
+    dispatch(fetchDailyTop50Spotify());
   };
 
-  const NewReleases = () => {
-    dispatch(fetchNewReleasesSpotify());
+  const dailyTop50 = () => {
+    dispatch(fetchDailyTop50Spotify());
     dispatch(clearPlaylistByID());
     setSearch("");
     setSearchMusic(false);
@@ -43,8 +43,8 @@ export default function SearchMusic() {
 
   return (
     <div className="searchMusicMain">
-      <button className="buttonBox" onClick={NewReleases}>
-        New Releases
+      <button className="buttonBox" onClick={dailyTop50}>
+        Daily Top-50
       </button>
       <button className="buttonBox" onClick={SearchMusic}>
         Search Music

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -4,7 +4,7 @@ import { useHistory } from "react-router-dom";
 
 import { selectUserToken } from "../store/user/selectors";
 import { selectSPOTIFYToken } from "../store/spotifyToken/selectors";
-import { fetchNewReleasesSpotify } from "../store/spotifyMusic/actions";
+import { fetchDailyTop50Spotify } from "../store/spotifyMusic/actions";
 
 import "./HomePage.css";
 
@@ -24,7 +24,7 @@ export default function HomePage() {
     if (!userToken) {
       history.push("/login");
     }
-    dispatch(fetchNewReleasesSpotify());
+    dispatch(fetchDailyTop50Spotify());
   });
 
   return (

--- a/src/spotify/SpotifyMusic.js
+++ b/src/spotify/SpotifyMusic.js
@@ -10,12 +10,12 @@ import { setSpotifySong } from "../store/playSong/actions";
 import { selectSearchInput } from "../store/searchInput/selectors";
 import {
   selectSpotifyMusic,
-  selectSpotifyNewReleases,
+  selectDailyTop50Spotify,
 } from "../store/spotifyMusic/selectors";
 
 export default function SpotifyMusic() {
   const song = useSelector(selectSpotifyMusic);
-  const newRleases = useSelector(selectSpotifyNewReleases);
+  const dailyTop50 = useSelector(selectDailyTop50Spotify);
   const search = useSelector(selectSearchInput);
   // const [track, setTrack] = useState("");
   const dispatch = useDispatch();
@@ -37,12 +37,18 @@ export default function SpotifyMusic() {
   //   if (index === array1[nextIndex]) return index;
   // });
 
+  const playAllDailyTop50 = () => {
+    const array = dailyTop50?.items?.map((song) => {
+      return song.track.uri;
+    });
+    dispatch(setSpotifySong(array));
+  };
+
   const playAllSearch = () => {
     const array = song?.items?.map((song) => {
       return song.uri;
     });
     dispatch(setSpotifySong(array));
-    console.log("new releases", array);
   };
 
   useEffect(() => {
@@ -59,26 +65,37 @@ export default function SpotifyMusic() {
       {song?.length === 0 ||
         (!song && (
           <>
-            {newRleases?.items?.map((tracks) => {
+            <button
+              onClick={playAllDailyTop50}
+              style={{
+                marginLeft: "5px",
+                border: "none",
+                borderBottom: "1px solid black",
+                cursor: "pointer",
+              }}
+            >
+              play all
+            </button>
+            {dailyTop50?.items?.map((data) => {
               return (
-                <div key={tracks.id}>
+                <div key={data.track.id}>
                   <div className="musicBox">
                     <div
                       onClick={() => {
-                        dispatch(setSpotifySong(tracks.uri));
-                        // setTrack(tracks.uri);
+                        dispatch(setSpotifySong(data.track.uri));
+                        // setTrack(data.uri);
 
                         // console.log("allUris:", array1);
                       }}
                       className="playSong"
                     >
-                      <MusicComponent img={tracks?.images[2].url} />
+                      <MusicComponent img={data?.track.album.images[2].url} />
                     </div>
                     <div className="songTitleArtistBox">
                       <div className="defaultTitleText">
-                        <MusicComponent title={tracks.name} />
+                        <MusicComponent title={data.track.name} />
                       </div>
-                      {tracks.artists.map((artists) => {
+                      {data.track.artists.map((artists) => {
                         return (
                           <div className="defaultArtistText" key={artists.id}>
                             <MusicComponent artist={artists.name} />
@@ -86,8 +103,8 @@ export default function SpotifyMusic() {
                         );
                       })}
                       <AddSongButton
-                        tracks={tracks}
-                        image={tracks.images[2].url}
+                        tracks={data}
+                        image={data?.track.album.images[2].url}
                       />
                     </div>
                   </div>

--- a/src/store/spotifyMusic/actions.js
+++ b/src/store/spotifyMusic/actions.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { useSelector } from "react-redux";
 
 import { appLoading, appDoneLoading } from "../appState/actions";
 
@@ -7,7 +6,7 @@ import { selectSearchInput } from "../searchInput/selectors";
 import { spotifyLogOut } from "../spotifyToken/actions";
 
 export const FETCH_SPOTIFY_MUSIC = "FETCH_SPOTIFY_MUSIC";
-export const NEW_SPOTIFY_MUSIC = "NEW_SPOTIFY_MUSIC";
+export const DAILY_SPOTIFY_TOP50 = "DAILY_SPOTIFY_TOP50";
 export const CLEAR_SPOTIFY_MUSIC = "CLEAR_SPOTIFY_MUSIC";
 
 export const fetchSpotifyMusicSucces = (spotifyMusic) => {
@@ -17,9 +16,9 @@ export const fetchSpotifyMusicSucces = (spotifyMusic) => {
   };
 };
 
-export const fetchNewReleasesSpotifySucces = (spotifyMusic) => {
+export const fetchDailyTop50Succes = (spotifyMusic) => {
   return {
-    type: NEW_SPOTIFY_MUSIC,
+    type: DAILY_SPOTIFY_TOP50,
     payload: spotifyMusic,
   };
 };
@@ -55,21 +54,22 @@ export const fetchSpotifyMusic = () => {
   };
 };
 
-export const fetchNewReleasesSpotify = () => {
+export const fetchDailyTop50Spotify = () => {
   return async (dispatch, getState) => {
     dispatch(appLoading());
     try {
       const spotifyToken = localStorage.getItem("spotifyToken");
 
       const response = await axios.get(
-        "https://api.spotify.com/v1/browse/new-releases?offset=0&limit=50",
+        "https://api.spotify.com/v1/playlists/37i9dQZEVXbMDoHDwVN2tF",
         {
           headers: {
             Authorization: `Bearer ${spotifyToken}`,
           },
         },
       );
-      dispatch(fetchNewReleasesSpotifySucces(response.data.albums));
+      console.log(response.data.tracks);
+      dispatch(fetchDailyTop50Succes(response.data.tracks));
     } catch (error) {
       console.log("Error:", error);
       if (error.response.status === 401) {

--- a/src/store/spotifyMusic/reducer.js
+++ b/src/store/spotifyMusic/reducer.js
@@ -1,12 +1,12 @@
 import {
   FETCH_SPOTIFY_MUSIC,
-  NEW_SPOTIFY_MUSIC,
+  DAILY_SPOTIFY_TOP50,
   CLEAR_SPOTIFY_MUSIC,
 } from "./actions";
 
 const initialState = {
   searchResults: {},
-  newReleases: {},
+  spotifyTop50: {},
 };
 
 export default function fetchMusicReducer(state = initialState, action) {
@@ -14,11 +14,11 @@ export default function fetchMusicReducer(state = initialState, action) {
     case FETCH_SPOTIFY_MUSIC:
       return { searchResults: { ...action.payload } };
 
-    case NEW_SPOTIFY_MUSIC:
-      return { newReleases: { ...action.payload } };
+    case DAILY_SPOTIFY_TOP50:
+      return { spotifyTop50: { ...action.payload } };
 
     case CLEAR_SPOTIFY_MUSIC:
-      return { searchResults: {}, newReleases: {} };
+      return { searchResults: {}, spotifyTop50: {} };
 
     default:
       return state;

--- a/src/store/spotifyMusic/selectors.js
+++ b/src/store/spotifyMusic/selectors.js
@@ -1,3 +1,3 @@
 export const selectSpotifyMusic = (state) => state.spotifyMusic.searchResults;
-export const selectSpotifyNewReleases = (state) =>
-  state.spotifyMusic.newReleases;
+export const selectDailyTop50Spotify = (state) =>
+  state.spotifyMusic.spotifyTop50;


### PR DESCRIPTION
Changed the New Releases to Daily Top 50 -- The new releases endpoint only gives URIS with album type instead of track, unfortunately track and album can't be mixed in the spotify player. Now the app shows Daily Global Top 50 songs by default, these songs all have URIS of the track type, now they can be added and played in playlists in the app.